### PR TITLE
Updated booster parent and removed redundant Arq Cube dependency

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <groupId>io.openshift</groupId>
     <artifactId>booster-parent</artifactId>
-    <version>11</version>
+    <version>13</version>
   </parent>
 
   <groupId>io.openshift.booster</groupId>
@@ -51,14 +51,6 @@
         <groupId>org.jboss.arquillian</groupId>
         <artifactId>arquillian-bom</artifactId>
         <version>${arquillian.version}</version>
-        <type>pom</type>
-        <scope>import</scope>
-      </dependency>
-
-      <dependency>
-        <groupId>org.arquillian.cube</groupId>
-        <artifactId>arquillian-cube-bom</artifactId>
-        <version>${arquillian.cube.version}</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -34,7 +34,6 @@
     <spring-boot.bom.version>1.5.8.Final</spring-boot.bom.version>
     <maven.spring-boot.plugin.version>1.5.8.RELEASE</maven.spring-boot.plugin.version>
     <arquillian.version>1.1.13.Final</arquillian.version>
-    <arquillian.cube.version>1.9.1</arquillian.cube.version>
   </properties>
 
   <dependencyManagement>


### PR DESCRIPTION
booster parent also contains newer version of Arq Cube makes @RouteURL work with parameters