### PR TITLE
fix: adds correct dependency to run cube tests

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -53,7 +53,7 @@
     <!-- Testing -->
     <dependency>
       <groupId>org.jboss.arquillian.junit</groupId>
-      <artifactId>arquillian-junit-container</artifactId>
+      <artifactId>arquillian-junit-standalone</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>


### PR DESCRIPTION
In `OpenshiftIT` we are using cube in [`standalone`](http://arquillian.org/arquillian-cube/#_arquillian_standalone_and_cube) mode, not using `container` mode. Hence changing it to use correct dependency.

