### PR TITLE
SB 347

### DIFF
--- a/.openshiftio/application.yaml
+++ b/.openshiftio/application.yaml
@@ -1,10 +1,14 @@
 apiVersion: v1
 kind: Template
 metadata:
-  name: launchpad-builder
+  name: spring-boot-rest-http
   annotations:
-    description: This template creates a Build Configuration using an S2I builder.
-    tags: instant-app
+    iconClass: icon-jboss
+    tags: spring-boot, rest, java, microservice
+    openshift.io/provider-display-name: "Red Hat, Inc."
+    openshift.io/documentation-url: "https://appdev.prod-preview.openshift.io/docs/spring-boot-runtime.html#mission-http-api-spring-boot-tomcat"
+    description: >-
+      The REST API Level 0 Mission provides a basic example of mapping business operations to a remote procedure call endpoint over HTTP using a REST framework.
 parameters:
 - name: SOURCE_REPOSITORY_URL
   description: The source URL for the application
@@ -59,14 +63,13 @@ objects:
     output:
       to:
         kind: ImageStreamTag
-        name: spring-boot-rest-http:13
+        name: spring-boot-rest-http:BOOSTER_VERSION
     postCommit: {}
     resources: {}
     source:
       git:
         uri: ${SOURCE_REPOSITORY_URL}
         ref: ${SOURCE_REPOSITORY_REF}
-      #contextDir: ${SOURCE_REPOSITORY_DIR}
       type: Git
     strategy:
       sourceStrategy:
@@ -99,7 +102,7 @@ objects:
     labels:
       app: spring-boot-rest-http
       provider: snowdrop
-      version: "13"
+      version: BOOSTER_VERSION
       group: io.openshift.booster
     name: spring-boot-rest-http
   spec:
@@ -118,7 +121,7 @@ objects:
     labels:
       app: spring-boot-rest-http
       provider: snowdrop
-      version: "13"
+      version: BOOSTER_VERSION
       group: io.openshift.booster
     name: spring-boot-rest-http
   spec:
@@ -136,7 +139,7 @@ objects:
         labels:
           app: spring-boot-rest-http
           provider: snowdrop
-          version: "13"
+          version: BOOSTER_VERSION
           group: io.openshift.booster
       spec:
         containers:
@@ -180,7 +183,7 @@ objects:
         - spring-boot
         from:
           kind: ImageStreamTag
-          name: spring-boot-rest-http:13
+          name: spring-boot-rest-http:BOOSTER_VERSION
       type: ImageChange
 - apiVersion: v1
   kind: Route
@@ -188,7 +191,7 @@ objects:
     labels:
       app: spring-boot-rest-http
       provider: snowdrop
-      version: "13"
+      version: BOOSTER_VERSION
       group: io.openshift.booster
     name: spring-boot-rest-http
   spec:

--- a/.openshiftio/application.yaml
+++ b/.openshiftio/application.yaml
@@ -149,7 +149,7 @@ objects:
             valueFrom:
               fieldRef:
                 fieldPath: metadata.namespace
-          image: spring-boot-rest-http:13
+          image: spring-boot-rest-http:BOOSTER_VERSION
           imagePullPolicy: IfNotPresent
           name: spring-boot
           ports:

--- a/.openshiftio/application.yaml
+++ b/.openshiftio/application.yaml
@@ -52,7 +52,7 @@ objects:
     name: runtime
   spec:
     tags:
-    - name: latest
+    - name: "RUNTIME_VERSION"
       from:
         kind: DockerImage
         name: registry.access.redhat.com/redhat-openjdk-18/openjdk18-openshift:RUNTIME_VERSION
@@ -103,7 +103,7 @@ objects:
     labels:
       app: spring-boot-rest-http
       provider: snowdrop
-      version: BOOSTER_VERSION
+      version: "BOOSTER_VERSION"
       group: io.openshift.booster
     name: spring-boot-rest-http
   spec:
@@ -122,7 +122,7 @@ objects:
     labels:
       app: spring-boot-rest-http
       provider: snowdrop
-      version: BOOSTER_VERSION
+      version: "BOOSTER_VERSION"
       group: io.openshift.booster
     name: spring-boot-rest-http
   spec:
@@ -140,7 +140,7 @@ objects:
         labels:
           app: spring-boot-rest-http
           provider: snowdrop
-          version: BOOSTER_VERSION
+          version: "BOOSTER_VERSION"
           group: io.openshift.booster
       spec:
         containers:
@@ -192,7 +192,7 @@ objects:
     labels:
       app: spring-boot-rest-http
       provider: snowdrop
-      version: BOOSTER_VERSION
+      version: "BOOSTER_VERSION"
       group: io.openshift.booster
     name: spring-boot-rest-http
   spec:

--- a/.openshiftio/application.yaml
+++ b/.openshiftio/application.yaml
@@ -3,8 +3,9 @@ kind: Template
 metadata:
   name: spring-boot-rest-http
   annotations:
-    iconClass: icon-jboss
+    iconClass: icon-spring
     tags: spring-boot, rest, java, microservice
+    openshift.io/display-name: Spring Boot - REST Http Endpoint
     openshift.io/provider-display-name: "Red Hat, Inc."
     openshift.io/documentation-url: "https://appdev.prod-preview.openshift.io/docs/spring-boot-runtime.html#mission-http-api-spring-boot-tomcat"
     description: >-

--- a/.openshiftio/application.yaml
+++ b/.openshiftio/application.yaml
@@ -55,7 +55,7 @@ objects:
     - name: latest
       from:
         kind: DockerImage
-        name: registry.access.redhat.com/redhat-openjdk-18/openjdk18-openshift
+        name: registry.access.redhat.com/redhat-openjdk-18/openjdk18-openshift:RUNTIME_VERSION
 - apiVersion: v1
   kind: BuildConfig
   metadata:
@@ -76,7 +76,7 @@ objects:
       sourceStrategy:
         from:
           kind: ImageStreamTag
-          name: runtime:latest
+          name: runtime:RUNTIME_VERSION
         incremental: true
         env:
         - name: MAVEN_ARGS_APPEND


### PR DESCRIPTION
- Remove F8 annotations
- Label fabric8 provider replaced by snowdrop
- Prometheus port removed as we don't use it
- Remose expose = true
- Replace the hard coded version within the template with a keyword. Proposition : use as keyword `BOOSTER_VERSION` for the booster version 
- Improve Template metadata