### PR TITLE
WIP - Add example of what template placeholder would look like

### DIFF
--- a/.openshiftio/application.yaml
+++ b/.openshiftio/application.yaml
@@ -52,10 +52,10 @@ objects:
     name: runtime
   spec:
     tags:
-    - name: "RUNTIME_VERSION"
+    - name: "${openjdk-openshift-image.version}"
       from:
         kind: DockerImage
-        name: registry.access.redhat.com/redhat-openjdk-18/openjdk18-openshift:RUNTIME_VERSION
+        name: registry.access.redhat.com/redhat-openjdk-18/openjdk18-openshift:${openjdk-openshift-image.version}
 - apiVersion: v1
   kind: BuildConfig
   metadata:
@@ -64,7 +64,7 @@ objects:
     output:
       to:
         kind: ImageStreamTag
-        name: spring-boot-rest-http:BOOSTER_VERSION
+        name: spring-boot-rest-http:${project.version}
     postCommit: {}
     resources: {}
     source:
@@ -76,7 +76,7 @@ objects:
       sourceStrategy:
         from:
           kind: ImageStreamTag
-          name: runtime:RUNTIME_VERSION
+          name: runtime:${openjdk-openshift-image.version}
         incremental: true
         env:
         - name: MAVEN_ARGS_APPEND
@@ -103,7 +103,7 @@ objects:
     labels:
       app: spring-boot-rest-http
       provider: snowdrop
-      version: "BOOSTER_VERSION"
+      version: "${project.version}"
       group: io.openshift.booster
     name: spring-boot-rest-http
   spec:
@@ -122,7 +122,7 @@ objects:
     labels:
       app: spring-boot-rest-http
       provider: snowdrop
-      version: "BOOSTER_VERSION"
+      version: "${project.version}"
       group: io.openshift.booster
     name: spring-boot-rest-http
   spec:
@@ -140,7 +140,7 @@ objects:
         labels:
           app: spring-boot-rest-http
           provider: snowdrop
-          version: "BOOSTER_VERSION"
+          version: "${project.version}"
           group: io.openshift.booster
       spec:
         containers:
@@ -149,7 +149,7 @@ objects:
             valueFrom:
               fieldRef:
                 fieldPath: metadata.namespace
-          image: spring-boot-rest-http:BOOSTER_VERSION
+          image: spring-boot-rest-http:${project.version}
           imagePullPolicy: IfNotPresent
           name: spring-boot
           ports:
@@ -184,7 +184,7 @@ objects:
         - spring-boot
         from:
           kind: ImageStreamTag
-          name: spring-boot-rest-http:BOOSTER_VERSION
+          name: spring-boot-rest-http:${project.version}
       type: ImageChange
 - apiVersion: v1
   kind: Route
@@ -192,7 +192,7 @@ objects:
     labels:
       app: spring-boot-rest-http
       provider: snowdrop
-      version: "BOOSTER_VERSION"
+      version: "${project.version}"
       group: io.openshift.booster
     name: spring-boot-rest-http
   spec:

--- a/pom.xml
+++ b/pom.xml
@@ -29,7 +29,9 @@
   <name>Spring Boot - HTTP Booster</name>
   <description>Spring Boot - HTTP Booster</description>
 
-  
+  <properties>
+      <openjdk-openshift-image.version>1.2-7</openjdk-openshift-image.version>
+  </properties>
 
   <dependencies>
     <!-- Spring Boot Starters -->
@@ -108,6 +110,25 @@
           </plugin>
         </plugins>
       </build>
+    </profile>
+    <profile>
+          <id>openshiftio</id>
+          <build>
+              <resources>
+                  <resource>
+                      <directory>src/main/resources</directory>
+                      <filtering>true</filtering>
+                  </resource>
+                  <resource>
+                      <directory>.openshiftio</directory>
+                      <includes>
+                          <include>*.yml</include>
+                          <include>*.yaml</include>
+                      </includes>
+                      <filtering>true</filtering>
+                  </resource>
+              </resources>
+          </build>
     </profile>
   </profiles>
 </project>


### PR DESCRIPTION
@metacosm This is a first attempt add fixing the template placeholder issue with Maven.

As you can see I added a new maven profile named `openshiftio` which declares the yaml files of `.opeshiftio` as maven resources.

When one executes

```bash
mvn clean resources:resources -Popenshiftio
```

then `.openshiftio/application.yaml` ends up in `target/classes/application.yaml` with the replaced values.