### PR TITLE
#4500 Modifying application.yaml as required by openshift.io osio pipeline library

### DIFF
--- a/.openshiftio/application.yaml
+++ b/.openshiftio/application.yaml
@@ -19,11 +19,6 @@ parameters:
   description: The release version number of application
   displayName: Release version
   value: 1.0.0
-- name: RUNTIME_VERSION
-  displayName: OpenJDK 8 image version to use
-  description: Specifies which version of the OpenShift OpenJDK 8 image to use
-  value: 1.3-8
-  required: true
 - name: SOURCE_REPOSITORY_URL
   description: The source URL for the application
   displayName: Source URL

--- a/.openshiftio/application.yaml
+++ b/.openshiftio/application.yaml
@@ -19,6 +19,11 @@ parameters:
   description: The release version number of application
   displayName: Release version
   value: 1.0.0
+- name: RUNTIME_VERSION
+  displayName: OpenJDK 8 image version to use
+  description: Specifies which version of the OpenShift OpenJDK 8 image to use
+  value: 1.3-8
+  required: true
 - name: SOURCE_REPOSITORY_URL
   description: The source URL for the application
   displayName: Source URL
@@ -62,10 +67,10 @@ objects:
     name: runtime
   spec:
     tags:
-    - name: "latest"
+    - name: "${RUNTIME_VERSION}"
       from:
         kind: DockerImage
-        name: registry.access.redhat.com/redhat-openjdk-18/openjdk18-openshift
+        name: registry.access.redhat.com/redhat-openjdk-18/openjdk18-openshift:${RUNTIME_VERSION}
 - apiVersion: v1
   kind: BuildConfig
   metadata:
@@ -88,7 +93,7 @@ objects:
       sourceStrategy:
         from:
           kind: ImageStreamTag
-          name: 'runtime:latest'
+          name: runtime:${RUNTIME_VERSION}
         incremental: true
         env:
         - name: MAVEN_ARGS_APPEND

--- a/.openshiftio/application.yaml
+++ b/.openshiftio/application.yaml
@@ -11,6 +11,14 @@ metadata:
     description: >-
       The REST API Level 0 Mission provides a basic example of mapping business operations to a remote procedure call endpoint over HTTP using a REST framework.
 parameters:
+- name: SUFFIX_NAME
+  description: The suffix name for the template objects
+  displayName: Suffix name
+  value: ''
+- name: RELEASE_VERSION
+  description: The release version number of application
+  displayName: Release version
+  value: 1.0.0
 - name: RUNTIME_VERSION
   displayName: OpenJDK 8 image version to use
   description: Specifies which version of the OpenShift OpenJDK 8 image to use
@@ -49,7 +57,9 @@ objects:
 - apiVersion: v1
   kind: ImageStream
   metadata:
-    name: spring-boot-rest-http
+    name: spring-boot-rest-http${SUFFIX_NAME}
+    labels:
+      version: ${RELEASE_VERSION}
   spec: {}
 - apiVersion: v1
   kind: ImageStream
@@ -57,19 +67,21 @@ objects:
     name: runtime
   spec:
     tags:
-    - name: "${RUNTIME_VERSION}"
+    - name: "latest"
       from:
         kind: DockerImage
-        name: registry.access.redhat.com/redhat-openjdk-18/openjdk18-openshift:${RUNTIME_VERSION}
+        name: registry.access.redhat.com/redhat-openjdk-18/openjdk18-openshift
 - apiVersion: v1
   kind: BuildConfig
   metadata:
-    name: spring-boot-rest-http
+    name: spring-boot-rest-http${SUFFIX_NAME}
+    labels:
+      version: ${RELEASE_VERSION}
   spec:
     output:
       to:
         kind: ImageStreamTag
-        name: spring-boot-rest-http:BOOSTER_VERSION
+        name: 'spring-boot-rest-http${SUFFIX_NAME}:${RELEASE_VERSION}'
     postCommit: {}
     resources: {}
     source:
@@ -81,7 +93,7 @@ objects:
       sourceStrategy:
         from:
           kind: ImageStreamTag
-          name: runtime:${RUNTIME_VERSION}
+          name: 'runtime:latest'
         incremental: true
         env:
         - name: MAVEN_ARGS_APPEND
@@ -106,11 +118,12 @@ objects:
   kind: Service
   metadata:
     labels:
+      expose: "true"
       app: spring-boot-rest-http
       provider: snowdrop
-      version: "BOOSTER_VERSION"
+      version: ${RELEASE_VERSION}
       group: io.openshift.booster
-    name: spring-boot-rest-http
+    name: spring-boot-rest-http${SUFFIX_NAME}
   spec:
     ports:
     - name: http
@@ -127,9 +140,9 @@ objects:
     labels:
       app: spring-boot-rest-http
       provider: snowdrop
-      version: "BOOSTER_VERSION"
+      version: ${RELEASE_VERSION}
       group: io.openshift.booster
-    name: spring-boot-rest-http
+    name: spring-boot-rest-http${SUFFIX_NAME}
   spec:
     replicas: 1
     selector:
@@ -145,7 +158,7 @@ objects:
         labels:
           app: spring-boot-rest-http
           provider: snowdrop
-          version: "BOOSTER_VERSION"
+          version: ${RELEASE_VERSION}
           group: io.openshift.booster
       spec:
         containers:
@@ -154,7 +167,7 @@ objects:
             valueFrom:
               fieldRef:
                 fieldPath: metadata.namespace
-          image: spring-boot-rest-http:BOOSTER_VERSION
+          image: ""
           imagePullPolicy: IfNotPresent
           name: spring-boot
           ports:
@@ -186,7 +199,7 @@ objects:
         - spring-boot
         from:
           kind: ImageStreamTag
-          name: spring-boot-rest-http:BOOSTER_VERSION
+          name: 'spring-boot-rest-http${SUFFIX_NAME}:${RELEASE_VERSION}'
       type: ImageChange
 - apiVersion: v1
   kind: Route
@@ -194,12 +207,12 @@ objects:
     labels:
       app: spring-boot-rest-http
       provider: snowdrop
-      version: "BOOSTER_VERSION"
+      version: ${RELEASE_VERSION}
       group: io.openshift.booster
-    name: spring-boot-rest-http
+    name: spring-boot-rest-http${SUFFIX_NAME}
   spec:
     port:
       targetPort: 8080
     to:
       kind: Service
-      name: spring-boot-rest-http
+      name: spring-boot-rest-http${SUFFIX_NAME}


### PR DESCRIPTION
openshiftio/openshift.io#4500
This changed include the below which is required by osio pipeline library (https://github.com/fabric8io/osio-pipeline) :

1. Adds parameter - RELEASE_VERSION which is basically the
build number and will be used to differentiate between
the resources of the particular build.
2. Adds parameter - SUFFIX_NAME which is an identifier to
differentiate between the master build or other branches.
More like a master build or PR build. So whenever there is
a change in the resources of a particular branch, it applies
to the resource of that branch only. The SUFFIX_NAME variable
is used in the name of all resources.